### PR TITLE
Fixed CD Pipeline by publishing every module under one repo.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,7 +50,7 @@ jobs:
           file: ./${{ matrix.service }}/Dockerfile
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service }}:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service }}:${{ steps.meta.outputs.sha_tag }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/shield:${{ matrix.service }}-latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/shield:${{ matrix.service }}-${{ steps.meta.outputs.sha_tag }}
           cache-from: type=gha,scope=build-${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=build-${{ matrix.service }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,7 +76,7 @@ services:
 
   # ── Custom BFF Gateway (Pushed Custom Image) ──────────────────────────────
   shield-gateway:
-    image: ${DOCKER_USER}/shield-gateway:latest
+    image: ${DOCKER_USER}/shield:shield-gateway-latest
     container_name: shield-gateway
     restart: always
     networks:
@@ -86,7 +86,7 @@ services:
 
   # ── Custom React Frontend Client (Pushed Custom Image) ────────────────────
   shield-frontend:
-    image: ${DOCKER_USER}/shield-frontend:latest
+    image: ${DOCKER_USER}/shield:shield-frontend-latest
     container_name: shield-frontend
     restart: always
     networks:
@@ -100,7 +100,7 @@ services:
 
   # ── Custom Authentication Service (Pushed Custom Image) ───────────────────
   shield-auth:
-    image: ${DOCKER_USER}/shield-auth:latest
+    image: ${DOCKER_USER}/shield:shield-auth-latest
     container_name: shield-auth
     restart: always
     networks:
@@ -122,7 +122,7 @@ services:
 
   # ── Custom Evidence Locker Service (Pushed Custom Image) ──────────────────
   shield-evidence:
-    image: ${DOCKER_USER}/shield-evidence:latest
+    image: ${DOCKER_USER}/shield:shield-evidence-latest
     container_name: shield-evidence
     restart: always
     networks:
@@ -145,7 +145,7 @@ services:
 
   # ── Custom Ledger Interface (Pushed Custom Image) ─────────────────────────
   shield-ledger:
-    image: ${DOCKER_USER}/shield-ledger:latest
+    image: ${DOCKER_USER}/shield:shield-ledger-latest
     container_name: shield-ledger
     restart: always
     networks:
@@ -161,7 +161,7 @@ services:
 
   # ── Custom Integrity Watchdog Daemon (Pushed Custom Image) ─────────────────
   shield-watchdog:
-    image: ${DOCKER_USER}/shield-watchdog:latest
+    image: ${DOCKER_USER}/shield:shield-watchdog-latest
     container_name: shield-watchdog
     restart: unless-stopped
     networks:


### PR DESCRIPTION
## 📝 Description
CD Pipeline was failing, due to the images not getting published on docker hub. The issue was with how docker hub dealt with private repos in a free account.

## 🔗 Related Issues / Pull Requests
Closes #39 

## 🛠️ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💡 New feature (non-breaking change which adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to behave unexpectedly)
- [ ] 📚 Documentation update (e.g., README.md, DATABASE.md, STRUCTURE.md)
- [x] ⚙️ CI/CD or infra configuration tweak (e.g. docker-compose, Github Actions)

## 🧪 Verification & Testing
<!-- Describe the test suites and manual validation processes run to confirm correct behavior. -->
### Local Test Suites Executed:
- [ ] **E2E Comprehensive Suite**: I ran `npm run test:comprehensive` locally and all 69 assertions passed.
- [ ] **Native Integration Suite**: I ran `npm run test:integration` locally and all 7 phases completed successfully.
- [ ] **Forensic Tamper Simulation**: I ran `npm run test:tamper` locally and the integrity watchdog successfully detected covert file modifications.

## 🔐 Security & Compliance Checklist
- [ ] **Zero-Trust Boundaries**: Verified that `Admin` role is strictly blocked (403) from accessing case reports and operational audit logs.
- [ ] **Exposed Credentials**: Ran GitGuardian verification and verified no real secrets/keys are exposed in code or commits (mock/test credentials are ignored via `.gitguardian.yml`).
- [ ] **Internal Network Guards**: Confirmed that service-to-service internal routes are guarded by appropriate IP whitelist guards.

## 📋 General PR Checklist:
- [x] My code conforms to the project standard patterns and contributing guidelines in `CONTRIBUTING.md`.
- [ ] I have updated the documentation accordingly if this change introduces new database fields, APIs, or environmental variables (e.g. `DATABASE.md` or `.env.example`).
- [x] I have rebased/merged the latest `main` branch into my feature branch prior to opening this request!
